### PR TITLE
Update pytest package and remove py package dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,12 +13,11 @@ macholib==1.14
 packaging==20.9
 pep517==0.10.0
 pluggy==0.13.1
-py==1.10.0
 pyinstaller-hooks-contrib==2021.2
 pyparsing==2.4.7
-pytest==6.2.3
+pytest==7.2.0
 pytest-cov==2.11.1
-PyYAML==5.4.1
+PyYAML~=6.0,>=6.0.1
 requests==2.31.0
 six==1.15.0
 toml==0.10.2


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

**py** vulnerability resolved via the fix mentioned in [this Dependabot fix](https://github.com/awslabs/amazon-emr-on-eks-custom-image-cli/security/dependabot/1), which is to update package pytest to `7.2.0` and remove dependency on `py` package. Which subsequently required updating PyYaml to `~=6.0,>=6.0.1` (based on [this aws-sam-cli fix](https://github.com/aws/aws-sam-cli/pull/5573))


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
